### PR TITLE
Add development credentials and override them when using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 2.3.0
 before_script:
+- cp config/database.travis.yml config/database.yml
 - psql -c 'create database deploy_spork_test;' -U postgres
 - rake db:test:load
 script: bundle exec rspec spec

--- a/config/database.travis.yml
+++ b/config/database.travis.yml
@@ -1,0 +1,10 @@
+# Custom database setup for CI (Travis in this case)
+test:
+  adapter:  postgresql
+  database: deploy_spork_test
+  encoding: unicode
+  host:     localhost
+  # password: password
+  pool:     5
+  template: template0
+  # username: vagrant

--- a/config/database.yml
+++ b/config/database.yml
@@ -45,10 +45,12 @@ test:
   database: deploy_spork_test
   encoding: unicode
   host:     localhost
+  password: password
   pool:     5
   template: template0
+  username: vagrant
 
-
+# Production on heroku uses ENV['DATABASE_URL'] for credentials
 production:
   adapter:  postgresql
   database: deploy_spork_production


### PR DESCRIPTION
Fixes bug where development credentials could not exist in the codebase because travis would fail.

Now, travis's custom database credentials (closely mimicking development/test) will replace the normal database file before tests are run.